### PR TITLE
add clone_node script

### DIFF
--- a/ubuntu-amd64/clone_node.sh
+++ b/ubuntu-amd64/clone_node.sh
@@ -2,21 +2,39 @@
 
 max_nodes=99
 
-working_directory=$PWD
-keygenerator_directory=$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/keygenerator
-source_directory=$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/node
+current_working_directory=$PWD
+source_config_directory="$GOPATH/src/github.com/ElrondNetwork/elrond-config"
+source_node_binary="$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/node/node"
+target_directory_prefix="$GOPATH/src/github.com/ElrondNetwork/elrond-go-node"
+keygenerator_directory="$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/keygenerator"
 
-for count in $(seq -f "%02g" 2 $max_nodes)
+for count in $(seq -f "%02g" 2 "$max_nodes")
 do
-	target_directory=$source_directory$count
+	target_directory="$target_directory_prefix-$count"
 	if [ ! -d "$target_directory" ]; then
+
 		echo "Creating clone of initial node in: $target_directory"
-		cp -R $source_directory $target_directory
-		cd $keygenerator_directory
+
+		#create working folder and copy source files
+		mkdir -p "$target_directory"/config
+		cp "$source_config_directory"/*.* "$target_directory"/config
+		cp "$source_node_binary" "$target_directory"
+
+		#choose node name
+		read -p "Choose the name of your node (default \"\"): " node_name
+		if [ ! "$node_name" = "" ]
+		then
+		    sed -i 's|NodeDisplayName = ""|NodeDisplayName = "'"$node_name"'"|g' "$target_directory"/config/config.toml
+		fi
+
+		#create new keys and copy them to the target config directory
+		cd "$keygenerator_directory"
 		./keygenerator
-        	cp initialBalancesSk.pem $target_directory/config/
-		cp initialNodesSk.pem $target_directory/config/
-                cd $working_directory
+        	cp initialBalancesSk.pem "$target_directory"/config
+		cp initialNodesSk.pem "$target_directory"/config
+
+		#return to the directory from which this script was executed
+                cd "$current_working_directory"
         	break
 	fi
 done

--- a/ubuntu-amd64/clone_node.sh
+++ b/ubuntu-amd64/clone_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+max_nodes=99
+
+working_directory=$PWD
+keygenerator_directory=$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/keygenerator
+source_directory=$GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/node
+
+for count in $(seq -f "%02g" 2 $max_nodes)
+do
+	target_directory=$source_directory$count
+	if [ ! -d "$target_directory" ]; then
+		echo "Creating clone of initial node in: $target_directory"
+		cp -R $source_directory $target_directory
+		cd $keygenerator_directory
+		./keygenerator
+        	cp initialBalancesSk.pem $target_directory/config/
+		cp initialNodesSk.pem $target_directory/config/
+                cd $working_directory
+        	break
+	fi
+done


### PR DESCRIPTION
Just wrote a bash script that creates a node02 --or node03 if node02 already exists, up to node99-- from the original node. Then it creates .pem keys for node02 and copies them to the node02 config directory.