### PR TITLE
Create get-github-repo.sh

### DIFF
--- a/ubuntu-amd64/get-github-repo.sh
+++ b/ubuntu-amd64/get-github-repo.sh
@@ -1,0 +1,4 @@
+#This script clean all changes made on this folder and reload the latest version from github
+
+cd ..
+git reset --hard master && git pull


### PR DESCRIPTION
This helps people to get the latest version of the elrond-go-scripts repo
You may create the same for windows
It's in a different file, not inside update.sh because when you make this pull, the file in use is not updated, in this case the only file that will be not updated with the git pull is this: get-github-repo.sh
On this way we make sure that update.sh is the latest version
I make some trials with it in my machines and it seems to work properly