### PR TITLE
Build proxy binary with ldflags

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -433,7 +433,8 @@ function elrond_proxy {
   echo -e
   echo -e "${GREEN}Building the elrond-proxy binary...${NC}"
   echo -e
-  cd $GOPATH/src/github.com/ElrondNetwork/elrond-proxy-go/cmd/proxy && go build
+  cd $GOPATH/src/github.com/ElrondNetwork/elrond-proxy-go/cmd/proxy && \
+        go build -ldflags="-X main.appVersion=$(git describe --tags --long --dirty) -X main.commitID=$(git rev-parse HEAD)"
   
   echo -e
   echo -e "${GREEN}Copying files to the elrond-proxy folder...${NC}"


### PR DESCRIPTION
- add build flags for proxy binary
- it should be backwards compatible
- this will be effective when https://github.com/ElrondNetwork/elrond-proxy-go/pull/332 will get in